### PR TITLE
fix: workbench for clients on multiplayer

### DIFF
--- a/UltimateStorageSystem/UltimateStorageSystem/ModEntry.cs
+++ b/UltimateStorageSystem/UltimateStorageSystem/ModEntry.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.IO;
 using System.Xml.Serialization;
 using Microsoft.Xna.Framework.Graphics;
+using HarmonyLib;
 
 #nullable disable
 
@@ -30,6 +31,7 @@ namespace UltimateStorageSystem
         private ModConfig config;
         private SButton? openTerminalHotkey;  // Nullable SButton für den Hotkey
         private readonly string farmLinkTerminalName = "holybananapants.UltimateStorageSystemContentPack_FarmLinkTerminal";
+        internal static string FarmLinkTerminalName => Instance.farmLinkTerminalName; // Required for the patch.
         public bool ignoreNextRightClick = true;
 
         public override void Entry(IModHelper helper)
@@ -39,8 +41,12 @@ namespace UltimateStorageSystem
             // Initiales Laden der Konfiguration aus der config.json
             LoadConfig();
 
-            // Laden der Texturen aus dem Assets Ordner            
+            // Laden der Texturen aus dem Assets Ordner
             basketTexture = helper.ModContent.Load<Texture2D>("Assets/basket.png");
+
+            // Patch all harmony patches.
+            Harmony harmony = new Harmony("holybananapants.UltimateStorageSystem");
+            harmony.PatchAll();
 
             helper.Events.Input.ButtonPressed += OnButtonPressed;
             helper.Events.World.ObjectListChanged += OnObjectListChanged;
@@ -78,26 +84,32 @@ namespace UltimateStorageSystem
 
         private void OnSaveLoaded(object sender, SaveLoadedEventArgs e)
         {
+            /* Unused now.
             foreach (var location in Game1.locations)
             {
                 CheckForFarmLinkTerminal(location);
             }
+            */
         }
 
         private void OnSaving(object sender, SavingEventArgs e)
         {
+            /* Unused now.
             foreach (var location in Game1.locations)
             {
                 ConvertCustomWorkbenchesToStandard(location);
             }
+            */
         }
 
         private void OnSaved(object sender, SavedEventArgs e)
         {
+            /* Unused now.
             foreach (var location in Game1.locations)
             {
                 CheckForFarmLinkTerminal(location);
             }
+            */
         }
 
         private void OnButtonPressed(object sender, ButtonPressedEventArgs e)
@@ -128,7 +140,9 @@ namespace UltimateStorageSystem
 
         private void OnLocationChanged(object sender, WarpedEventArgs e)
         {
+            /* Unused now.
             CheckForFarmLinkTerminal(e.NewLocation);
+            */
         }
 
         private void OnObjectListChanged(object sender, ObjectListChangedEventArgs e)
@@ -138,7 +152,9 @@ namespace UltimateStorageSystem
                 RevertCustomWorkbenches(e.Location);
             }
 
+            /* Unused now.
             CheckForFarmLinkTerminal(e.Location);
+            */
         }
 
         private bool IsFarmLinkTerminalPlaced()
@@ -158,6 +174,7 @@ namespace UltimateStorageSystem
             return false;
         }
 
+        /* Unused now.
         private void CheckForFarmLinkTerminal(GameLocation location)
         {
             List<KeyValuePair<Vector2, Workbench>> workbenchesToReplace = new List<KeyValuePair<Vector2, Workbench>>();
@@ -179,7 +196,9 @@ namespace UltimateStorageSystem
                 location.objects.Add(pair.Key, new CustomWorkbench(pair.Key));
             }
         }
+        */
 
+        /* Unused now.
         private bool IsTerminalAdjacent(Vector2 tileLocation, GameLocation location)
         {
             foreach (var offset in AdjacentTilesOffsets)
@@ -192,7 +211,9 @@ namespace UltimateStorageSystem
             }
             return false;
         }
+        */
 
+        // Still use this to unpatch ny CustomWorkbenches if required.
         private void RevertCustomWorkbenches(GameLocation location)
         {
             List<Vector2> customWorkbenchesToRevert = new List<Vector2>();
@@ -212,6 +233,7 @@ namespace UltimateStorageSystem
             }
         }
 
+        /* Unused now.
         private void ConvertCustomWorkbenchesToStandard(GameLocation location)
         {
             List<Vector2> customWorkbenchesToRevert = new List<Vector2>();
@@ -230,6 +252,7 @@ namespace UltimateStorageSystem
                 location.objects.Add(tileLocation, new Workbench(tileLocation));
             }
         }
+        */
 
         private bool IsFarmLinkTerminalOnTile(Vector2 tile, out StardewValley.Object terminalObject)
         {
@@ -263,7 +286,7 @@ namespace UltimateStorageSystem
                 // Kühlschrank im Farmhaus prüfen
                 if (location is FarmHouse)
                 {
-                    Chest fridge = (location as FarmHouse).fridge.Value;                    
+                    Chest fridge = (location as FarmHouse).fridge.Value;
                     if (fridge != null)
                     {
                         chests.Add(fridge);
@@ -295,7 +318,7 @@ namespace UltimateStorageSystem
             return chests;
         }
 
-        private static readonly Vector2[] AdjacentTilesOffsets = new Vector2[]
+        internal static readonly Vector2[] AdjacentTilesOffsets = new Vector2[] // Changed to internal static for the patch.
         {
             new Vector2(-1f, 1f),
             new Vector2(0f, 1f),

--- a/UltimateStorageSystem/UltimateStorageSystem/Overrides/CustomWorkbench.cs
+++ b/UltimateStorageSystem/UltimateStorageSystem/Overrides/CustomWorkbench.cs
@@ -19,6 +19,7 @@ namespace UltimateStorageSystem.Overrides
     [Serializable]
     public class CustomWorkbench : Workbench
     {
+      /* Whole class is unused we don't need to have anything inside now.
         public static readonly NetMutex globalChestMutex = new NetMutex();
 
         // Default constructor
@@ -127,5 +128,6 @@ namespace UltimateStorageSystem.Overrides
                 globalChestMutex.Update(location);
             base.updateWhenCurrentLocation(time);
         }
+        */
     }
 }

--- a/UltimateStorageSystem/UltimateStorageSystem/Patches/WorkbenchPatch.cs
+++ b/UltimateStorageSystem/UltimateStorageSystem/Patches/WorkbenchPatch.cs
@@ -1,0 +1,147 @@
+// WORKBENCHPATCH.CS
+// This file defines a custom workbench that overrides the default behavior,
+// allowing it to interact with all chests in the game while managing global access locks.
+
+using Microsoft.Xna.Framework;
+using StardewValley;
+using StardewValley.Objects;
+using StardewValley.Menus;
+using StardewValley.Network;
+using System;
+using System.Collections.Generic;
+using StardewValley.Inventories;
+using StardewValley.Locations;
+using HarmonyLib;
+
+namespace UltimateStorageSystem.Patches
+{
+    [HarmonyPatch(typeof(Workbench), nameof(Workbench.checkForAction))]
+    public static class Workbench_checkForAction_Patch
+    {
+        private static bool IsTerminalAdjacent(Vector2 tileLocation, GameLocation location)
+        {
+            foreach (var offset in ModEntry.AdjacentTilesOffsets)
+            {
+                Vector2 adjacentTile = tileLocation + offset;
+                if (location.objects.TryGetValue(adjacentTile, out StardewValley.Object adjacentObject) && adjacentObject.Name == ModEntry.FarmLinkTerminalName)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        // Overrides the method called when the player interacts with the workbench
+        public static bool Prefix(Workbench __instance, ref bool __result, Farmer who, bool justCheckingForActivity /* = false */) {
+            GameLocation location = __instance.Location;
+            if (location == null) {
+                __result = false; // Set the return value of the Workbench.checkForAction method to default. (Probably not needed)
+                return true;      // Then continue to the original method.
+            }
+            if (justCheckingForActivity) {
+                __result = false; // Set the return value of the Workbench.checkForAction method to default. (Probably not needed)
+                return true;      // Then continue to the original method.
+            }
+            if (IsTerminalAdjacent(__instance.TileLocation, location)) {
+                // Creates a list of all chests found
+                List<Chest> chestList = new List<Chest>();
+
+                void AddChestsFromLocation(GameLocation location)
+                {
+                    // Alle Objekte in der Location durchsuchen
+                    foreach (var item in location.objects.Values)
+                    {
+                        if (item is Chest chest &&
+                            (chest.SpecialChestType == Chest.SpecialChestTypes.None || chest.SpecialChestType == Chest.SpecialChestTypes.BigChest))
+                        {
+                            chestList.Add(chest);
+                        }
+                    }
+
+                    // Kühlschrank im Farmhaus prüfen
+                    if (location is FarmHouse farmHouse)
+                    {
+                        Chest fridge = farmHouse.fridge.Value;
+                        if (fridge != null)
+                        {
+                            chestList.Add(fridge);
+                        }
+                    }
+
+                    // Gebäude in spezifischen Locations durchsuchen
+                    if (location is Farm || location.Name == "FarmHouse" || location.Name == "Shed" || location.Name.Contains("Cabin"))
+                    {
+                        if (location is Farm farm)
+                        {
+                            foreach (var building in farm.buildings)
+                            {
+                                if (building.indoors.Value != null)
+                                {
+                                    AddChestsFromLocation(building.indoors.Value);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Durchlaufe alle Locations im Spiel
+                foreach (var gameLocation in Game1.locations)
+                {
+                    AddChestsFromLocation(gameLocation);
+                }
+
+                // Creates a list for the inventories of the found chests
+                List<IInventory> inventories = new List<IInventory>();
+
+                foreach (Chest chest in chestList)
+                {
+                    // Adds the chest's inventory to the inventory list
+                    inventories.Add((IInventory)chest.Items);
+                }
+
+                // If the global chest lock is not set, executes the following logic
+                if (!__instance.mutex.IsLocked())
+                {
+                    // Locks all chests for other players, but the workbench itself can use them
+                    __instance.mutex.RequestLock(() =>
+                    {
+                        // Centers the crafting menu on the screen
+                        Vector2 centeringOnScreen = Utility.getTopLeftPositionForCenteringOnScreen(800 + IClickableMenu.borderWidth * 2, 600 + IClickableMenu.borderWidth * 2);
+                        // Opens the crafting menu with the collected inventories
+                        Game1.activeClickableMenu = new CraftingPage((int)centeringOnScreen.X, (int)centeringOnScreen.Y, 800 + IClickableMenu.borderWidth * 2, 600 + IClickableMenu.borderWidth * 2, standaloneMenu: true, materialContainers: inventories);
+                        // Sets a function to execute when the menu is closed
+                        Game1.activeClickableMenu.exitFunction = () =>
+                        {
+                            // Releases the global chest lock
+                            __instance.mutex.ReleaseLock();
+                        };
+                    },
+                    () =>
+                    {
+                        // If locking the chests fails, displays an error message
+                        Game1.showRedMessage(Game1.content.LoadString("Strings\\UI:Workbench_Chest_Warning"));
+                    });
+                }
+
+                __result = true; // Returns that the action was successful // Set the return value of the Workbench.checkForAction method to true. (is for sure needed)
+                return false;    // Does not continue the parent function. // Do not continue to the original method.
+            }
+
+            __result = false; // Set the return value of the Workbench.checkForAction method to default. (Probably not needed)
+            return true;      // Then continue to the original method.
+        }
+    }
+
+    [HarmonyPatch(typeof(Workbench), nameof(Workbench.updateWhenCurrentLocation))]
+    public static class Workbench_updateWhenCurrentLocation_Patch
+    {
+        // Overrides the method that updates the workbench in the current location
+        public static bool Prefix(Workbench __instance)
+        {
+            GameLocation location = __instance.Location;
+            if (location != null)
+                __instance.mutex.Update(location);
+            return true; // continue to the original method.
+        }
+    }
+}

--- a/UltimateStorageSystem/UltimateStorageSystem/UltimateStorageSystem.csproj
+++ b/UltimateStorageSystem/UltimateStorageSystem/UltimateStorageSystem.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <EnableHarmony>true</EnableHarmony>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I found that the workbench does not open on multiplayer for clients, but does work for the host. I have changed the system to use Harmony instead of completely overwriting all workbenches on the farm.